### PR TITLE
Tycho 1.5 and p2 dependencies optimisation

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.1</version>
   </extension>
 </extensions>

--- a/constraint/pom.xml
+++ b/constraint/pom.xml
@@ -41,7 +41,6 @@
     </modules>
 
     <properties>
-        <tycho-version>1.2.0</tycho-version>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
     </properties>
 

--- a/mapping/deployment/org.eclipse.gemoc.moccml.mapping.build/pom.xml
+++ b/mapping/deployment/org.eclipse.gemoc.moccml.mapping.build/pom.xml
@@ -37,8 +37,6 @@
 	</parent>
 
 	<properties>
-		<tycho-version>1.2.0</tycho-version>
-		<tycho-extras-version>1.2.0</tycho-extras-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
                 <maven.compiler.target>1.8</maven.compiler.target>
                 <maven.compiler.source>1.8</maven.compiler.source>
@@ -153,7 +151,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho-extras-version}</version>
+				<version>${tycho-version}</version>
 				<executions>
 					<execution>
 						<id>source-feature</id>

--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,6 @@
             <layout>p2</layout>
             <url>http://download.eclipse.org/tools/ajdt/46/dev/update</url>
         </repository>
-        <repository> <!-- this repo is used to provide jdom and jaxen plugins -->
-            <id>app4mc</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.0/</url>
-        </repository>
     </repositories>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<packaging>pom</packaging>
 
     <properties>
-		<tycho-version>1.2.0</tycho-version>
+		<tycho-version>1.5.1</tycho-version>
     	<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/gemoc/concurrency.git</tycho.scmUrl>


### PR DESCRIPTION
Companion PR of https://github.com/eclipse/gemoc-studio/pull/189

This PR tries to optimize the build time on the CI with the following changes:

- update tycho from 1.2.0 to 1.5.1
- remove p2 repository APP4MC 