### PR TITLE
Deploy GEMOC artefacts to maven repository (repo.eclipse.org)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,9 @@
 		<tycho-version>1.5.1</tycho-version>
     	<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
-		<tycho.scmUrl>scm:git:https://github.com/gemoc/concurrency.git</tycho.scmUrl>
+		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-moccml.git</tycho.scmUrl>
+		
+		<maven.deploy.skip>true</maven.deploy.skip>
 	</properties>
 	<modules>
 		<module>mapping/deployment/org.eclipse.gemoc.moccml.mapping.build</module>


### PR DESCRIPTION
Companion PR of https://github.com/eclipse/gemoc-studio/pull/204