### PR TITLE
Bump Studio to 3.4.0

### DIFF
--- a/constraint/plugins/AS/org.eclipse.gemoc.moccml.constraint.ccslmocc.model/plugin.properties
+++ b/constraint/plugins/AS/org.eclipse.gemoc.moccml.constraint.ccslmocc.model/plugin.properties
@@ -25,4 +25,4 @@
 # $Id$
 
 pluginName = MoCCML MoCC (CCSL&Automata) Model
-providerName = ENSTA Bretagne
+providerName = Eclipse GEMOC Project

--- a/constraint/plugins/AS/org.eclipse.gemoc.moccml.constraint.fsmkernel.model/plugin.properties
+++ b/constraint/plugins/AS/org.eclipse.gemoc.moccml.constraint.fsmkernel.model/plugin.properties
@@ -25,4 +25,4 @@
 # $Id$
 
 pluginName = MoCCML Automata Kernel Model
-providerName = ENSTA Bretagne
+providerName = Eclipse GEMOC Project

--- a/constraint/plugins/editors/graphical/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.design/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/graphical/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.design/OSGI-INF/l10n/bundle.properties
@@ -23,5 +23,5 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML MoCC (CCSL&Automata) DSL Design plugin

--- a/constraint/plugins/editors/graphical/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.design/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/graphical/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.design/OSGI-INF/l10n/bundle.properties
@@ -23,5 +23,5 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML Automata DSL Design

--- a/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl.ui/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl.ui/OSGI-INF/l10n/bundle.properties
@@ -23,7 +23,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML MoCC (CCSL&Automata) DSL xtext ui
 editor.name = MoCCML Editor
 wizard.name = MoCCML Project

--- a/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl/OSGI-INF/l10n/bundle.properties
@@ -22,5 +22,5 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML MoCC (CCSL&Automata) DSL xtext

--- a/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl.ui/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl.ui/OSGI-INF/l10n/bundle.properties
@@ -23,7 +23,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML Automata xtext ui
 editor.name = AutomataDsl Editor
 wizard.name = AutomataDsl Project

--- a/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl/OSGI-INF/l10n/bundle.properties
+++ b/constraint/plugins/editors/textual/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl/OSGI-INF/l10n/bundle.properties
@@ -23,5 +23,5 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #   
 # $Id$
-Bundle-Vendor = ENSTA Bretagne
+Bundle-Vendor = Eclipse GEMOC Project
 Bundle-Name = MoCCML Automata DSL xtext

--- a/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.edit/plugin.properties
+++ b/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.edit/plugin.properties
@@ -24,7 +24,7 @@
 # $Id$
 
 pluginName = Ccslmocc Edit Support
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_CreateChild_text = {0}
 _UI_CreateChild_text2 = {1} {0}

--- a/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.editor/plugin.properties
+++ b/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.editor/plugin.properties
@@ -24,7 +24,7 @@
 # $Id$
 
 pluginName = Ccslmocc Editor
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_CcslmoccEditor_menu = &Ccslmocc Editor
 

--- a/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.edit/plugin.properties
+++ b/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.edit/plugin.properties
@@ -25,7 +25,7 @@
 # $Id$
 
 pluginName = MoCCML Automata Kernel Edit Support
-providerName = ENSTA Bretagne
+providerName = Eclipse GEMOC Project
 
 _UI_CreateChild_text = {0}
 _UI_CreateChild_text2 = {1} {0}

--- a/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.editor/plugin.properties
+++ b/constraint/plugins/editors/tree/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.editor/plugin.properties
@@ -25,7 +25,7 @@
 # $Id$
 
 pluginName = MoCCML Automata Kernel Editor Support
-providerName = ENSTA Bretagne
+providerName = Eclipse GEMOC Project
 
 
 _UI_CreateChild_menu_item = &New Child

--- a/constraint/plugins/solver/org.eclipse.gemoc.moccml.constraint.ccslkernel.solver.extension.statemachine/META-INF/MANIFEST.MF
+++ b/constraint/plugins/solver/org.eclipse.gemoc.moccml.constraint.ccslkernel.solver.extension.statemachine/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: StateMachineSolverExtension
 Bundle-SymbolicName: org.eclipse.gemoc.moccml.constraint.ccslkernel.solver.extension.statemachine;singleton:=true
 Bundle-Version: 0.1.1.qualifier
 Bundle-Activator: org.eclipse.gemoc.moccml.constraint.ccslkernel.solver.extension.statemachine.Activator
-Bundle-Vendor: Aoste INRIA/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.core.runtime,
  fr.inria.aoste.timesquare.ccslkernel.model;bundle-version="1.0.0",
  fr.inria.aoste.timesquare.ccslkernel.modelunfolding;bundle-version="1.0.0",

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.ccsl.solver.extension.automata.feature/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.ccsl.solver.extension.automata.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl.sdk/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.ccslmocc.model.xtext.mocdsl.sdk/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.core.feature/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.core.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.feature/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl.sdk/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.fsmkernel.model.xtext.fsmdsl.sdk/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.graphical.editors.feature/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.graphical.editors.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/constraint/releng/org.eclipse.gemoc.moccml.constraint.text.editors.feature/feature.properties
+++ b/constraint/releng/org.eclipse.gemoc.moccml.constraint.text.editors.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.edit/plugin.properties
+++ b/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.edit/plugin.properties
@@ -11,7 +11,7 @@
 #
 
 pluginName = Feedback Edit Support
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_CreateChild_text = {0}
 _UI_CreateChild_text2 = {1} {0}

--- a/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.editor/plugin.properties
+++ b/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.editor/plugin.properties
@@ -11,7 +11,7 @@
 #
 
 pluginName = Feedback Editor
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_FeedbackEditor_menu = &Feedback Editor
 

--- a/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.feature/feature.xml
+++ b/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.feature/feature.xml
@@ -9,18 +9,17 @@
     Contributors:
         I3S laboratory - initial API and implementation
  -->
-
 <feature
       id="org.eclipse.gemoc.moccml.mapping.feedback.model.feature"
       label="the feedback execution model "
       version="1.0.0.qualifier"
-      provider-name="Aoste INRIA / I3S">
+      provider-name="Eclipse GEMOC Project">
 
    <description url="http://www.example.com/description">
       [Enter Feature Description here.]
    </description>
 
-<copyright url="http://www.eclipse.org/legal/epl-v10.html">
+   <copyright url="http://www.eclipse.org/legal/epl-v10.html">
       Copyright (c) 2012, 2017 I3S Laboratory and others
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +32,7 @@ http://www.eclipse.org/legal/epl-v10.html
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
    </license>
+
    <url>
       <update label="GEMOC update site" url="https://download.eclipse.org/gemoc/updates/nightly/"/>
       <discovery label="Neon" url="http://download.eclipse.org/releases/neon/"/>

--- a/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.tests/plugin.properties
+++ b/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model.tests/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = Feedback Tests
-providerName = www.example.org
+providerName = Eclipse GEMOC Project

--- a/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model/plugin.properties
+++ b/mapping/feedback/model/org.eclipse.gemoc.moccml.mapping.feedback.model/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = Feedback Model
-providerName = www.example.org
+providerName = Eclipse GEMOC Project

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping.editor.feature/feature.xml
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping.editor.feature/feature.xml
@@ -13,7 +13,7 @@
       id="org.eclipse.gemoc.moccml.mapping.editor.feature"
       label="ECL model and editor"
       version="1.0.0.qualifier"
-      provider-name="Aoste INRIA / I3S">
+      provider-name="Eclipse GEMOC Project">
 
    <description url="http://timesquare.inria.fr/ecl">
       the ECL language and transformation to specify the concurrent
@@ -42,7 +42,6 @@ and timing aspect of your language ! (Ie. moccml.mapings)
       <discovery label="Acceleo" url="http://download.eclipse.org/modeling/m2t/acceleo/updates/releases/3.2"/>
       <discovery label="Xtext All In One - Releases" url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
       <discovery label="TimeSquare" url="http://timesquare.inria.fr/update_site/photon"/>
-      
    </url>
 
    <requires>

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext.ui/META-INF/MANIFEST.MF
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext.ui/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.moccml.mapping.xtext.ui
-Bundle-Vendor: INRIA/I3S Aoste
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.eclipse.gemoc.moccml.mapping.xtext.ui;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext/META-INF/MANIFEST.MF
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.eclipse.gemoc.moccml.mapping.xtext
-Bundle-Vendor: Aoste INRIA/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.eclipse.gemoc.moccml.mapping.xtext;singleton:=true
 Bundle-ActivationPolicy: lazy

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping/META-INF/MANIFEST.MF
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.gemoc.moccml.mapping;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-ClassPath: bin/,
  .
-Bundle-Vendor: %Aoste INRIA / I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Localization: plugin
 Export-Package: org.eclipse.gemoc.moccml.mapping.moccml_mapping,
  org.eclipse.gemoc.moccml.mapping.moccml_mapping.impl,

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping/plugin.properties
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = Ecl Model
-providerName = www.example.org
+providerName = Eclipse GEMOC Project

--- a/mapping/org.eclipse.gemoc.moccml.mapping.feature/feature.xml
+++ b/mapping/org.eclipse.gemoc.moccml.mapping.feature/feature.xml
@@ -13,7 +13,7 @@
       id="org.eclipse.gemoc.moccml.mapping.feature"
       label="Moccml Mapping SDK"
       version="1.0.0.qualifier"
-      provider-name="Aoste INRIA / I3S">
+      provider-name="Eclipse GEMOC Project">
 
    <description url="http://www.example.com/description">
       Editors and transformations for developping Moccml mappings using ECL
@@ -39,7 +39,7 @@ which accompanies this distribution, and is available at http://www.eclipse.org/
       <discovery label="The Eclipse Project Updates" url="http://download.eclipse.org/eclipse/updates/4.15"/>
       <discovery label="Acceleo" url="http://download.eclipse.org/modeling/m2t/acceleo/updates/releases/3.2"/>
       <discovery label="Xtext All In One - Releases" url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
-      <discovery label="TimeSquare" url="ttp://timesquare.inria.fr/update_site/photon"/>
+      <discovery label="TimeSquare"/>
    </url>
 
    <includes

--- a/mapping/transformations/org.eclipse.gemoc.moccml.mapping.ecltoqvto.ui/META-INF/MANIFEST.MF
+++ b/mapping/transformations/org.eclipse.gemoc.moccml.mapping.ecltoqvto.ui/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Require-Bundle: org.eclipse.ui,
  fr.inria.aoste.timesquare.ccslkernel.parser.xtext,
  org.eclipse.xtext,
  org.eclipse.gemoc.moccml.mapping.xtext
-Bundle-Vendor: Aoste Inria/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 1.0.0.qualifier
 Bundle-Name: ecl to qvto ui

--- a/mapping/transformations/org.eclipse.gemoc.moccml.mapping.ecltoqvto/META-INF/MANIFEST.MF
+++ b/mapping/transformations/org.eclipse.gemoc.moccml.mapping.ecltoqvto/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Acceleo Ecltoqvto Module Runtime Plug-in
 Bundle-SymbolicName: org.eclipse.gemoc.moccml.mapping.ecltoqvto
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.moccml.mapping.ecltoqvto.Activator
-Bundle-Vendor: Aoste Inria/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,

--- a/mapping/transformations/org.eclipse.gemoc.moccml.mapping.qvto.helper/META-INF/MANIFEST.MF
+++ b/mapping/transformations/org.eclipse.gemoc.moccml.mapping.qvto.helper/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.xtext,
  fr.inria.aoste.timesquare.ccslkernel.library.xtext;bundle-version="1.0.0",
  fr.inria.aoste.timesquare.ccslkernel.parser.xtext
-Bundle-Vendor: Aoste INRIA/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 1.0.0.qualifier
 Bundle-Name: QVTo Helper

--- a/mapping/transformations/org.eclipse.gemoc.moccml.mapping.qvto2ccsl.ui/META-INF/MANIFEST.MF
+++ b/mapping/transformations/org.eclipse.gemoc.moccml.mapping.qvto2ccsl.ui/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Require-Bundle: org.eclipse.ui,
  fr.inria.aoste.timesquare.ccslkernel.parser.xtext;bundle-version="1.0.0",
  org.eclipse.m2m.qvt.oml,
  org.eclipse.xtext
-Bundle-Vendor: Aoste INRIA/I3S
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-ActivationPolicy: lazy
 Bundle-Version: 1.0.0.qualifier
 Bundle-Name: qvto to ccsl Ui

--- a/mapping/transformations/org.eclipse.gemoc.moccml.mapping.transfos.feature/feature.xml
+++ b/mapping/transformations/org.eclipse.gemoc.moccml.mapping.transfos.feature/feature.xml
@@ -9,18 +9,17 @@
     Contributors:
         I3S laboratory - initial API and implementation
  -->
-
 <feature
       id="org.eclipse.gemoc.moccml.mapping.transfos.feature"
       label="transformations for ECL Feature"
       version="1.0.0.qualifier"
-      provider-name="Aoste INRIA / I3S">
+      provider-name="Eclipse GEMOC Project">
 
    <description url="http://www.example.com/description">
       MoCCML mapping transformation to generate your concurrency model compiler from the specification at the language level(installation means installing everything)
    </description>
 
-<copyright url="http://www.eclipse.org/legal/epl-v10.html">
+   <copyright url="http://www.eclipse.org/legal/epl-v10.html">
       Copyright (c) 2012, 2017 I3S Laboratory and others
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +32,7 @@ http://www.eclipse.org/legal/epl-v10.html
 are made available under the terms of the Eclipse Public License v1.0
 which accompanies this distribution, and is available at http://www.eclipse.org/legal/epl-v10.html
    </license>
+
    <url>
       <update label="GEMOC update site" url="https://download.eclipse.org/gemoc/updates/nightly/"/>
       <discovery label="Luna" url="http://download.eclipse.org/releases/luna/"/>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
     <properties>

--- a/releng/org.eclipse.gemoc.moccml.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.moccml.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.moccml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.moccml.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.moccml.feature"
       label="GEMOC MOCCML"
-      version="2.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 


### PR DESCRIPTION
## Description

Increase Studio version to 3.4.0.xxx

Update vendor name of all plugins and features to `Eclipse GEMOC Project`

## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/235

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - https://github.com/eclipse/gemoc-studio/pull/236
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/198
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/55
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/50
- https://github.com/eclipse/gemoc-studio-execution-java/pull/20