### PR TITLE
Fixes usage of GEMOC updatesite with recent Eclipse package

### DIFF
--- a/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext/META-INF/MANIFEST.MF
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping.xtext/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: org.eclipse.gemoc.moccml.mapping.xtext;singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.gemoc.moccml.mapping,
- org.eclipse.xtext;bundle-version="2.21.0";visibility:=reexport,
+ org.eclipse.xtext;bundle-version="[2.21.0,3.0.0)";visibility:=reexport,
  org.apache.log4j;bundle-version="1.2.15";visibility:=reexport,
  org.apache.commons.logging;bundle-version="1.0.4";resolution:=optional;visibility:=reexport,
  org.eclipse.xtext.generator,
@@ -22,14 +22,14 @@ Require-Bundle: org.eclipse.gemoc.moccml.mapping,
  fr.inria.aoste.timesquare.ccslkernel.library.xtext;bundle-version="1.0.0",
  org.eclipse.ocl.xtext.markup.ui,
  org.eclipse.uml2.codegen.ecore;bundle-version="1.8.0",
- org.eclipse.ocl.xtext.essentialocl.ui;bundle-version="[1.10.0,1.16.0)",
+ org.eclipse.ocl.xtext.essentialocl.ui;bundle-version="[1.10.0,2.0.0)",
  fr.inria.aoste.timesquare.ccslkernel.parser.xtext,
  org.eclipse.jdt.annotation,
  org.eclipse.uml2.uml;bundle-version="5.0.0",
- org.eclipse.ocl.xtext.base;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
- org.eclipse.ocl.xtext.essentialocl;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
- org.eclipse.ocl.pivot;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
- org.eclipse.ocl.xtext.completeocl;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
+ org.eclipse.ocl.xtext.base;bundle-version="1.10.0";visibility:=reexport,
+ org.eclipse.ocl.xtext.essentialocl;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
+ org.eclipse.ocl.pivot;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
+ org.eclipse.ocl.xtext.completeocl;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
  org.eclipse.ocl.examples.codegen
 Import-Package: org.apache.log4j,
  org.apache.commons.logging

--- a/mapping/language/org.eclipse.gemoc.moccml.mapping/META-INF/MANIFEST.MF
+++ b/mapping/language/org.eclipse.gemoc.moccml.mapping/META-INF/MANIFEST.MF
@@ -14,11 +14,11 @@ Export-Package: org.eclipse.gemoc.moccml.mapping.moccml_mapping,
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.jdt.annotation;visibility:=reexport,
- org.eclipse.ocl.xtext.base;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
- org.eclipse.ocl.xtext.completeocl;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
- org.eclipse.ocl.xtext.essentialocl;bundle-version="[1.10.0,1.16.0)";visibility:=reexport,
+ org.eclipse.ocl.xtext.base;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
+ org.eclipse.ocl.xtext.completeocl;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
+ org.eclipse.ocl.xtext.essentialocl;bundle-version="[1.10.0,2.0.0)";visibility:=reexport,
  fr.inria.aoste.timesquare.ccslkernel.model;visibility:=reexport,
- org.eclipse.ocl.pivot;bundle-version="[1.10.0,1.16.0)";visibility:=reexport
+ org.eclipse.ocl.pivot;bundle-version="[1.10.0,2.0.0)";visibility:=reexport
 Eclipse-LazyStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
## Description

Enable use of the GEMOC Update site for recent Eclipse package (Ie. eclipse package newer than the version used to compile the studio/updatesite)

## Changes

relax upper bound version on dependencies of moccml plugins
 
## Contribution to issues

Contributes to https://github.com/eclipse/gemoc-studio/issues/248

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio/pull/250
