### PR TITLE
Bump to 3.5.0

### DIFF
--- a/constraint/pom.xml
+++ b/constraint/pom.xml
@@ -9,7 +9,7 @@
     <parent>
 		<groupId>org.eclipse.gemoc</groupId>
 		<artifactId>org.eclipse.gemoc.concurrent.root</artifactId>
-    	<version>3.4.0-SNAPSHOT</version>
+    	<version>3.5.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/mapping/deployment/org.eclipse.gemoc.moccml.mapping.build/pom.xml
+++ b/mapping/deployment/org.eclipse.gemoc.moccml.mapping.build/pom.xml
@@ -32,7 +32,7 @@
     <parent>
 		<groupId>org.eclipse.gemoc</groupId>
 		<artifactId>org.eclipse.gemoc.concurrent.root</artifactId>
-    	<version>3.4.0-SNAPSHOT</version>
+    	<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.gemoc</groupId>
 	<artifactId>org.eclipse.gemoc.concurrent.root</artifactId>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
     <properties>

--- a/releng/org.eclipse.gemoc.moccml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.moccml.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.moccml.feature"
       label="GEMOC MOCCML"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc</groupId>
 		<artifactId>org.eclipse.gemoc.concurrent.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
 	</parent>
 	


### PR DESCRIPTION
## Description

Bump GEMOC Studio version to 3.5.0

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/254
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/212
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/64
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/51
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/22